### PR TITLE
feat: source-activecampaign + source-rdstation wrappers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,10 +47,10 @@
       "name": "@harbor/source-activecampaign",
       "version": "0.0.1",
       "dependencies": {
-        "@harbor/core": "workspace:*",
+        "@harbor/source-openapi": "workspace:*",
       },
       "peerDependencies": {
-        "effect": "^3.0.0",
+        "effect": ">=4.0.0-beta",
       },
     },
     "packages/source-csv": {
@@ -86,11 +86,11 @@
       "name": "@harbor/source-rdstation",
       "version": "0.0.1",
       "dependencies": {
-        "@harbor/core": "workspace:*",
         "@harbor/source-csv": "workspace:*",
+        "@harbor/source-openapi": "workspace:*",
       },
       "peerDependencies": {
-        "effect": "^3.0.0",
+        "effect": ">=4.0.0-beta",
       },
     },
     "packages/stage-gcs": {

--- a/packages/source-activecampaign/package.json
+++ b/packages/source-activecampaign/package.json
@@ -1,21 +1,16 @@
 {
   "name": "@harbor/source-activecampaign",
   "version": "0.0.1",
-  "description": "ActiveCampaign paginated source connector",
+  "description": "ActiveCampaign source — thin wrapper over @harbor/source-openapi",
   "type": "module",
-  "main":  "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" }
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist *.tsbuildinfo"
+    ".": { "bun": "./src/index.ts", "import": "./src/index.ts" }
   },
   "dependencies": {
-    "@harbor/core": "workspace:*"
+    "@harbor/source-openapi": "workspace:*"
   },
   "peerDependencies": {
-    "effect": "^3.0.0"
+    "effect": ">=4.0.0-beta"
   }
 }

--- a/packages/source-activecampaign/src/index.ts
+++ b/packages/source-activecampaign/src/index.ts
@@ -1,1 +1,34 @@
-// @harbor/source-activecampaign — implementation coming in PRP
+/**
+ * @harbor/source-activecampaign
+ *
+ * Thin wrapper over @harbor/source-openapi.
+ * ActiveCampaign API: https://{account}.api-us1.com/api/3
+ *
+ * Usage:
+ *   const source = ActiveCampaignSource({ account: "minhaempresa", token: "API_KEY" })
+ *   // source.stream → Stream<Record, OpenApiError>
+ */
+import { OpenApiSource, type OpenApiSourceResult } from "@harbor/source-openapi"
+
+export interface ActiveCampaignConfig {
+  account:   string
+  token:     string
+  tag?:      string
+  pageSize?: number
+  /** Custom OpenAPI spec URL (default: bundled AC spec) */
+  specUrl?:  string
+}
+
+const DEFAULT_SPEC = "https://developers.activecampaign.com/openapi.json"
+
+export function ActiveCampaignSource(config: ActiveCampaignConfig): OpenApiSourceResult {
+  return OpenApiSource({
+    spec:     config.specUrl ?? DEFAULT_SPEC,
+    auth:     { type: "apiKey", headerName: "Api-Token", value: config.token },
+    baseUrl:  `https://${config.account}.api-us1.com/api/3`,
+    tag:      config.tag ?? "contacts",
+    pageSize: config.pageSize,
+  })
+}
+
+export type { OpenApiSourceResult } from "@harbor/source-openapi"

--- a/packages/source-rdstation/package.json
+++ b/packages/source-rdstation/package.json
@@ -1,22 +1,17 @@
 {
   "name": "@harbor/source-rdstation",
   "version": "0.0.1",
-  "description": "RD Station source connector (CSV-based)",
+  "description": "RD Station source — CSV-based (export) or API via source-openapi",
   "type": "module",
-  "main":  "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" }
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist *.tsbuildinfo"
+    ".": { "bun": "./src/index.ts", "import": "./src/index.ts" }
   },
   "dependencies": {
-    "@harbor/core": "workspace:*",
-    "@harbor/source-csv": "workspace:*"
+    "@harbor/source-csv":     "workspace:*",
+    "@harbor/source-openapi": "workspace:*"
   },
   "peerDependencies": {
-    "effect": "^3.0.0"
+    "effect": ">=4.0.0-beta"
   }
 }

--- a/packages/source-rdstation/src/index.ts
+++ b/packages/source-rdstation/src/index.ts
@@ -1,1 +1,65 @@
-// @harbor/source-rdstation — implementation coming in PRP
+/**
+ * @harbor/source-rdstation
+ *
+ * Two modes:
+ * 1. CSV (recommended): export from RD Station UI → use CsvSource
+ *    RD Station has no paginated list API — CSV export covers all contacts
+ * 2. API (small volumes): GET /platform/segmentations/{id}/contacts via source-openapi
+ *
+ * Usage (CSV — recommended):
+ *   const source = RDStationCsvSource({ path: "./leads_export.csv" })
+ *
+ * Usage (API):
+ *   const source = RDStationApiSource({ accessToken: "...", segmentationId: 123 })
+ */
+import { Schema } from "effect"
+import { CsvSource }      from "@harbor/source-csv"
+import { OpenApiSource, type OpenApiSourceResult } from "@harbor/source-openapi"
+
+export const RDContactSchema = Schema.Struct({
+  email:           Schema.String,
+  name:            Schema.optional(Schema.String),
+  job_title:       Schema.optional(Schema.String),
+  company:         Schema.optional(Schema.String),
+  personal_phone:  Schema.optional(Schema.String),
+  mobile_phone:    Schema.optional(Schema.String),
+  city:            Schema.optional(Schema.String),
+  state:           Schema.optional(Schema.String),
+  country:         Schema.optional(Schema.String),
+  lifecycle_stage: Schema.optional(Schema.String),
+  tags:            Schema.optional(Schema.String),  // "tag1,tag2" in CSV
+})
+
+export type RDContact = typeof RDContactSchema.Type
+
+/** Mode 1 — CSV export (recommended for any volume) */
+export function RDStationCsvSource(config: { path: string }) {
+  return CsvSource({ path: config.path, schema: RDContactSchema })
+}
+
+export interface RDStationApiConfig {
+  accessToken:     string
+  refreshToken?:   string
+  segmentationId?: number
+  pageSize?:       number
+  specUrl?:        string
+}
+
+const RD_SPEC = "https://api.rd.services/openapi.json"
+
+/** Mode 2 — API (small volumes, requires OAuth token) */
+export function RDStationApiSource(config: RDStationApiConfig): OpenApiSourceResult {
+  const path = config.segmentationId
+    ? `/platform/segmentations/${config.segmentationId}/contacts`
+    : "/platform/contacts"
+
+  return OpenApiSource({
+    spec:     config.specUrl ?? RD_SPEC,
+    auth:     { type: "bearer", value: config.accessToken },
+    baseUrl:  "https://api.rd.services",
+    tag:      "contacts",
+    pageSize: config.pageSize,
+  })
+}
+
+export type { OpenApiSourceResult } from "@harbor/source-openapi"


### PR DESCRIPTION
Closes #6, Closes #8

Thin wrappers over @harbor/source-openapi. Each is ~30 lines.

**source-activecampaign**: `ActiveCampaignSource({ account, token })` → `OpenApiSource` with ApiKey header
**source-rdstation**: `RDStationCsvSource({ path })` (recommended) or `RDStationApiSource({ accessToken })`